### PR TITLE
systemd reload handler now uses systemd module

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,4 +2,5 @@
 - name: reload systemd daemon
   become: true
   become_user: root
-  command: systemctl daemon-reload
+  systemd:
+    daemon-reload: yes


### PR DESCRIPTION
Using `ansible-lint` I'm finding the following when running plays with this role:

```$ ansible-lint playbooks/prom_exporter.yml 
[ANSIBLE0006] systemctl used in place of systemd module
/ansible/roles/bdellegrazie.ansible-role-prometheus_exporter/handlers/main.yml:2
Task/Handler: reload systemd daemon

[ANSIBLE0006] systemctl used in place of systemd module
/ansible/roles/bdellegrazie.ansible-role-prometheus_exporter/handlers/main.yml:2
Task/Handler: reload systemd daemon
```

Thanks so much for your roles @bdellegrazie great stuff!! :+1: 