### PR TITLE
libselinux-python3

### DIFF
--- a/vars/vars-family-redhat-8.yml
+++ b/vars/vars-family-redhat-8.yml
@@ -1,0 +1,3 @@
+---
+prometheus_exporter_ansible_packages:
+  - libselinux-python3


### PR DESCRIPTION
RedHat 8 uses libselinux-python3 instead of libselinux-python